### PR TITLE
(Alper | Issiz Adam)  ve (Yuddy | Days of Being Wild) yer degistir

### DIFF
--- a/liste.csv
+++ b/liste.csv
@@ -29,8 +29,8 @@ Imhotep,Mumya
 Daltonlar,Red Kid
 Vahsi,Cagri
 Ho Po Wing,Happy Together
-Alper,Issiz Adam
 Yuddy,Days of being wild
+Alper,Issiz Adam
 Hayri,Neredesin Firuze
 Muhtar,Bir Zamanlar Anadoluda
 Aysegul,Kucuk Sirlar


### PR DESCRIPTION
Karakter: {Karakterin ismi ve bulunduğu filmin ismi}

Pozisyon: (Alper | Issiz Adam) ve (Ho Po Wing | Happy Together) arasina

Sebep: Yuddy de Issiz adam sayilir ama ek olarak ihtiyaci olmadigi halde sahte pasaport cikarttirmak ve adam oldurmek suclari da var